### PR TITLE
chore(claude): security-guidance プラグインを有効化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "security-guidance@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
## 概要

Claude Code のセキュリティ診断プラグイン `security-guidance@claude-plugins-official` を本リポジトリで有効化する。`.claude/settings.json` の `enabledPlugins` に登録するだけの設定追加で、アプリケーション挙動には影響しない。

## 変更点

- `.claude/settings.json` に `enabledPlugins.security-guidance@claude-plugins-official: true` を追加

## 影響範囲

- staging / production の挙動: 影響なし (Claude Code セッション内のプラグイン構成のみ変更)
- CI: 影響なし
- ローカル開発: Claude Code セッションで `/security-review` 等のセキュリティ診断系コマンドが使えるようになる

## 受入試験

`.claude/` 配下のみの変更で staging 挙動に影響しないため、受入試験は省略する。